### PR TITLE
Add auto find of encryption functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ The public key is encrypted inside the shared library, and a function called `ro
 ## How to use the script
 This script assumes that you have already rooted and installed Frida on your Android device.
 ```console
-$ frida -l "D:\akamai-bmp-rsa-hook.js" -f  com.ihg.apps.android -U
+$ frida -l "D:\akamai-bmp-rsa-hook.js" -f com.ihg.apps.android -U --no-pause
 ```
 
 ## Output
 Below is an example of the output from the script (*screenshot purposly cropped to stop you being lazy...*)
 
-![output](https://i.imgur.com/AHtNNfc.png)
+![output](https://i.imgur.com/FpmV2fm.png)

--- a/README.md
+++ b/README.md
@@ -9,23 +9,12 @@ The public key is encrypted inside the shared library, and a function called `ro
 ![](https://i.imgur.com/7z8RQlU.png)
 
 ## How to use the script
-> This script was tested on an Android ARM device. You will need to adjust the memory addresses for any other architectures. 
-
-> This script assumes that you have already rooted and installed Frida on your Android device.
-
-`frida -l "D:\akamai-bmp-rsa-hook.js" -f  com.ihg.apps.android -U`
+This script assumes that you have already rooted and installed Frida on your Android device.
+```console
+$ frida -l "D:\akamai-bmp-rsa-hook.js" -f  com.ihg.apps.android -U
+```
 
 ## Output
 Below is an example of the output from the script (*screenshot purposly cropped to stop you being lazy...*)
 
-![enter image description here](https://i.imgur.com/AHtNNfc.png)
-
-## Finding the memory address of RSAEncrypt
-
- 1. Unzip an APK that uses Akamai BMP 3.3.0
- 2. Load the `libakamaibmp.so` file from `/lib/arm64-v8a` (if using an ARM device, if not, select the correct file for your architecture) in Ghidra
- 3. Search for `RSAEncrypt` in the Symbol Tree
- 4. Replace the memory address in the script (variable `rsaEncryptAddr`) with the one highlighted in the screenshot
- 5. Ensure the base image address is correct by clicking; Window -> Memory Map -> Set Image Base. If it is different, replace the correct value in the Frida script (`ghidraImageBase`)
-
-![enter image description here](https://i.imgur.com/TPvy6RB.png)
+![output](https://i.imgur.com/AHtNNfc.png)

--- a/akamai-bmp-rsa-hook.js
+++ b/akamai-bmp-rsa-hook.js
@@ -1,14 +1,27 @@
 function processJniOnLoad(libraryName) {
-	const rsaEncryptAddr = 0x001a4258; //Address of the RSAEncrypt method, as found in Ghidra
-	const ghidraImageBase = 0x00100000; //Base image address
+  const library = Process.getModuleByName(libraryName);
 
-	//RSAEncrypt Hook (encrypts the encryption keys)
-    	const membase = Module.findBaseAddress(libraryName);
-    	console.log("[+] Base address is " + membase);
-	
-	//Find the actual address by subtracting the image base
-	const actualRsaEncryptAddress = membase.add(rsaEncryptAddr - ghidraImageBase);
-    	console.log("[+] Actual RSA Encrypt Address " + actualRsaEncryptAddress);
+  let exports = library.enumerateExports();
+  let actualRsaEncryptAddress = null;
+  let actualAesEncryptAddress = null;
+  for (let i = 0; i  < exports.length; i ++) {
+    const element = exports[i];
+    if(element.name.includes("RSAEncrypt")) {
+      actualRsaEncryptAddress = element.address;
+    }
+    else if(element.name.includes("AESEncrypt")) {
+      actualAesEncryptAddress = element.address;
+    }
+  }
+
+  if(actualRsaEncryptAddress == null) {
+    throw("No RSAEncrypt found. Try adjusting your filter.");
+  }
+  if(actualAesEncryptAddress == null) {
+    throw("No AESEncrypt found. Try adjusting your filter.");
+  }
+
+  console.log("[+] Actual RSA Encrypt Address " + actualRsaEncryptAddress);
 
 	Interceptor.attach(actualRsaEncryptAddress, {
 		onEnter: function(args) {
@@ -23,22 +36,18 @@ function processJniOnLoad(libraryName) {
 	
 	
 	//AESEncrypt Hook (encrypts the sensor)
-	const aesEncryptAddr = 0x001a3ff4; //Address of the AESEncrypt method, as found in Ghidra
-    	const aesEncryptBase = Module.findBaseAddress(libraryName);
-    	console.log("[+] AESEncrypt Base address is " + aesEncryptBase);
-	const actualAesEncryptAddress = membase.add(aesEncryptAddr - ghidraImageBase);
-    	console.log("[+] Actual AESEncrypt Address " + actualAesEncryptAddress);
-	
-	Interceptor.attach(actualAesEncryptAddress, {
-		onEnter: function(args) {
-			console.log("Hooked AESEncrypt");
-			const plainSensor = Memory.readUtf8String(args[0]); //sensor is the first arg, and is type uchar *
-			console.log(plainSensor);
-		},
-		onLeave: function(retval) {
-			console.log("Leaving AESEncrypt");
-		}
-	});
+  console.log("[+] Actual AESEncrypt Address " + actualAesEncryptAddress);
+
+  Interceptor.attach(actualAesEncryptAddress, {
+    onEnter: function(args) {
+      console.log("Hooked AESEncrypt");
+      const plainSensor = Memory.readUtf8String(args[0]); //sensor is the first arg, and is type uchar *
+      console.log(plainSensor);
+    },
+    onLeave: function(retval) {
+      console.log("Leaving AESEncrypt");
+    }
+  });
 }
 
 function waitForLibLoading(libraryName) {


### PR DESCRIPTION
This improvements automates address finding of functions that we're interested in. It should work for every app where the shared library's export name includes RSAEncrypt and AESEncrypt, but I only checked Zalando.
I removed "Finding the memory address of RSAEncrypt" section from README.md since it's no longer needed.